### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/frontend/here-driver-app/amplify/backend/geo/hereMapDriversRoutes1/hereMapDriversRoutes1-cloudformation-template.json
+++ b/frontend/here-driver-app/amplify/backend/geo/hereMapDriversRoutes1/hereMapDriversRoutes1-cloudformation-template.json
@@ -191,7 +191,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/frontend/here-driver-app/export-amplify-stack/amplify-export-heredriverapp/auth/heredriverapp34ffc390/heredriverapp34ffc390-cloudformation-template.json
+++ b/frontend/here-driver-app/export-amplify-stack/amplify-export-heredriverapp/auth/heredriverapp34ffc390/heredriverapp34ffc390-cloudformation-template.json
@@ -297,7 +297,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/frontend/here-driver-app/export-amplify-stack/amplify-export-heredriverapp/geo/hereMapDriversRoutes1/hereMapDriversRoutes1-cloudformation-template.json
+++ b/frontend/here-driver-app/export-amplify-stack/amplify-export-heredriverapp/geo/hereMapDriversRoutes1/hereMapDriversRoutes1-cloudformation-template.json
@@ -191,7 +191,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/frontend/here-driver-app/export-amplify-stack/amplify-export-heredriverapp/root-stack-template.json
+++ b/frontend/here-driver-app/export-amplify-stack/amplify-export-heredriverapp/root-stack-template.json
@@ -284,7 +284,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300,
         "Role": {
           "Fn::GetAtt": [


### PR DESCRIPTION
CloudFormation templates in aws-here-optimize-fleet-utilization have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.